### PR TITLE
feat: Configure GCS authentication for Netlify

### DIFF
--- a/src/lib/gcsService.js
+++ b/src/lib/gcsService.js
@@ -2,9 +2,18 @@
 import { GoogleAuth } from 'google-auth-library';
 
 async function getGcsAuthToken() {
-  const auth = new GoogleAuth({
-    scopes: 'https://www.googleapis.com/auth/devstorage.read_only',
-  });
+  let auth;
+  if (process.env.GOOGLE_APPLICATION_CREDENTIALS_JSON) {
+    const credentials = JSON.parse(process.env.GOOGLE_APPLICATION_CREDENTIALS_JSON);
+    auth = new GoogleAuth({
+      credentials,
+      scopes: 'https://www.googleapis.com/auth/devstorage.read_only',
+    });
+  } else {
+    auth = new GoogleAuth({
+      scopes: 'https://www.googleapis.com/auth/devstorage.read_only',
+    });
+  }
   const client = await auth.getClient();
   const accessToken = (await client.getAccessToken()).token;
   if (!accessToken) {


### PR DESCRIPTION
Updates `gcsService.js` to allow authentication to Google Cloud Storage using a service account JSON key provided via the
`GOOGLE_APPLICATION_CREDENTIALS_JSON` environment variable.

This enables the application to authenticate to GCS when deployed on Netlify, where Application Default Credentials are not automatically available. The changes maintain fallback to default credentials for local development or other environments.